### PR TITLE
Update cmake-presets-vs.md #3446

### DIFF
--- a/docs/build/cmake-presets-vs.md
+++ b/docs/build/cmake-presets-vs.md
@@ -223,6 +223,22 @@ Build with `clang`:
 }
 ```
 
+*OR* use the `toolset` configure preset to specify the `ClangCL` toolset like so:
+  
+```json
+"cacheVariables": {
+  "CMAKE_BUILD_TYPE": "Debug",
+  "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+},
+"toolset": "ClangCL",
+
+"vendor": {
+  "microsoft.com/VisualStudioSettings/CMake/1.0": {
+    "intelliSenseMode": "windows-clang-x64"
+  }
+}
+```
+  
 > [!IMPORTANT]
 > In Visual Studio 2019, you must explicitly specify a Clang IntelliSense mode when you're building with `clang` or `clang-cl`.
 


### PR DESCRIPTION
Add instructions for configuring clang-cl with the ClangCL toolset configure preset instead of by setting CMAKE_C_COMPILER and CMAKE_CXX_COMPILER in cacheVariables.

Pull request for issue #3446